### PR TITLE
 Adding check for escape character to resolve issue #6899

### DIFF
--- a/Syntaxes/Chapel.tmLanguage
+++ b/Syntaxes/Chapel.tmLanguage
@@ -80,6 +80,17 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.double.chapel</string>
+			<key>patterns</key>
+					<array>
+							<dict>
+								<key>include</key>
+								<string>#string_escaped_char</string>
+							</dict>
+							<dict>
+								<key>include</key>
+								<string>#string_placeholder</string>
+							</dict>
+				 </array>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -258,9 +269,9 @@
 		<dict>
 			<key>match</key>
 			<string>(?x)\b(
-              	abs | max | min | sqrt | write | writeln | read | readln | open | close | 
+              	abs | max | min | sqrt | write | writeln | read | readln | open | close |
 				exit
-			
+
 			)\b</string>
 			<key>name</key>
 			<string>support.function.builtin.chapel</string>
@@ -371,6 +382,44 @@
 			<string>\b(align|as|atomic|begin|break|by|catch|class|cobegin|coforall|continue|delete|dmapped|do|else|enum|except|export|extern|for|forall|if|index|inline|in|iter|label|lambda|let|local|module|new|noinit|on|only|otherwise|pragma|private|proc|public|record|reduce|require|return|scan|select|serial|then|throw|throws|try|union|use|var|when|where|while|with|yield|zip)\b</string>
 			<key>name</key>
 			<string>invalid.illegal.name.chapel</string>
+		</dict>
+		<key>string_escaped_char</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
+					<key>name</key>
+					<string>constant.character.escape.c</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\.</string>
+					<key>name</key>
+					<string>invalid.illegal.unknown-escape.c</string>
+				</dict>
+			</array>
+		</dict>
+		<key>string_placeholder</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>(?x)%
+    						(\d+\$)?                             # field (argument #)
+    						[#0\- +']*                           # flags
+    						[,;:_]?                              # separator character (AltiVec)
+    						((-?\d+)|\*(-?\d+\$)?)?              # minimum field width
+    						(\.((-?\d+)|\*(-?\d+\$)?)?)?         # precision
+    						(hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier
+    						[diouxXDOUeEfFgGaACcSspn%]           # conversion type
+    					</string>
+					<key>name</key>
+					<string>constant.other.placeholder.c</string>
+				</dict>
+			</array>
 		</dict>
 	</dict>
 	<key>scopeName</key>

--- a/Syntaxes/Chapel.tmLanguage
+++ b/Syntaxes/Chapel.tmLanguage
@@ -81,16 +81,16 @@
 			<key>name</key>
 			<string>string.quoted.double.chapel</string>
 			<key>patterns</key>
-					<array>
-							<dict>
-								<key>include</key>
-								<string>#string_escaped_char</string>
-							</dict>
-							<dict>
-								<key>include</key>
-								<string>#string_placeholder</string>
-							</dict>
-				 </array>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#string_escaped_char</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#string_placeholder</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -269,9 +269,9 @@
 		<dict>
 			<key>match</key>
 			<string>(?x)\b(
-              	abs | max | min | sqrt | write | writeln | read | readln | open | close |
+              	abs | max | min | sqrt | write | writeln | read | readln | open | close | 
 				exit
-
+			
 			)\b</string>
 			<key>name</key>
 			<string>support.function.builtin.chapel</string>

--- a/Syntaxes/Chapel.tmLanguage
+++ b/Syntaxes/Chapel.tmLanguage
@@ -383,44 +383,6 @@
 			<key>name</key>
 			<string>invalid.illegal.name.chapel</string>
 		</dict>
-		<key>string_escaped_char</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
-					<key>name</key>
-					<string>constant.character.escape.c</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\\.</string>
-					<key>name</key>
-					<string>invalid.illegal.unknown-escape.c</string>
-				</dict>
-			</array>
-		</dict>
-		<key>string_placeholder</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>(?x)%
-    						(\d+\$)?                             # field (argument #)
-    						[#0\- +']*                           # flags
-    						[,;:_]?                              # separator character (AltiVec)
-    						((-?\d+)|\*(-?\d+\$)?)?              # minimum field width
-    						(\.((-?\d+)|\*(-?\d+\$)?)?)?         # precision
-    						(hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier
-    						[diouxXDOUeEfFgGaACcSspn%]           # conversion type
-    					</string>
-					<key>name</key>
-					<string>constant.other.placeholder.c</string>
-				</dict>
-			</array>
-		</dict>
 	</dict>
 	<key>scopeName</key>
 	<string>source.chapel</string>

--- a/Syntaxes/Chapel.tmLanguage
+++ b/Syntaxes/Chapel.tmLanguage
@@ -23,13 +23,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(align|as|atomic|begin|break|by|catch|class|cobegin|coforall|continue|delete|dmapped|do|else|enum|except|export|extern|for|forall|if|index|inline|in|iter|label|lambda|let|local|module|new|noinit|on|only|otherwise|pragma|private|proc|prototype|public|record|reduce|require|return|scan|select|serial|then|throw|throws|try|union|use|var|when|where|while|with|yield|zip)\b</string>
+			<string>\b(align|as|atomic|begin|break|by|catch|class|cobegin|coforall|continue|delete|dmapped|do|else|enum|except|export|extern|for|forall|if|index|inline|in|inout|iter|label|lambda|let|local|module|new|noinit|on|only|otherwise|out|pragma|private|proc|prototype|public|record|reduce|ref|require|return|scan|select|serial|then|throw|throws|try|union|use|var|when|where|while|with|yield|zip)\b</string>
 			<key>name</key>
 			<string>keyword.control.chapel</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(bool|real|int|uint|imag|complex|dmap|domain|string|range|tuple)\b</string>
+			<string>\b(bool|real|int|uint|imag|complex|dmap|domain|opaque|string|range|subdomain|sync|tuple)\b</string>
 			<key>name</key>
 			<string>storage.type.chapel</string>
 		</dict>
@@ -85,10 +85,6 @@
 				<dict>
 					<key>include</key>
 					<string>#string_escaped_char</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#string_placeholder</string>
 				</dict>
 			</array>
 		</dict>
@@ -379,10 +375,28 @@
 		<key>illegal_names</key>
 		<dict>
 			<key>match</key>
-			<string>\b(align|as|atomic|begin|break|by|catch|class|cobegin|coforall|continue|delete|dmapped|do|else|enum|except|export|extern|for|forall|if|index|inline|in|iter|label|lambda|let|local|module|new|noinit|on|only|otherwise|pragma|private|proc|public|record|reduce|require|return|scan|select|serial|then|throw|throws|try|union|use|var|when|where|while|with|yield|zip)\b</string>
+			<string>\b(align|as|atomic|begin|break|by|catch|class|cobegin|coforall|continue|delete|dmapped|do|else|enum|except|export|extern|for|forall|if|index|inline|in|inout|iter|label|lambda|let|local|module|new|noinit|on|only|otherwise|out|pragma|private|proc|public|record|reduce|ref|require|return|scan|select|serial|then|throw|throws|try|union|use|var|when|where|while|with|yield|zip)\b</string>
 			<key>name</key>
 			<string>invalid.illegal.name.chapel</string>
 		</dict>
+		<key>string_escaped_char</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
+					<key>name</key>
+					<string>constant.character.escape.c</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\.</string>
+					<key>name</key>
+					<string>invalid.illegal.unknown-escape.c</string>
+				</dict>
+			</array>
+		</dict>		
 	</dict>
 	<key>scopeName</key>
 	<string>source.chapel</string>


### PR DESCRIPTION
@lydia-duncan I have added check to resolve the  issue **Incorrect Syntax Highlighting For Escaped Character '\"' #6899** by adding **#string_escaped_char** and **#string_placeholder** . As there is no check for the escape character  provided in the chapel tmbundle . 
Kindly review the changes done and the next PR for the description of **#string_escaped_char** and **#string_placeholder** is #9 