### PR TITLE
 Description of #string_escaped_char and #string_placeholder to resolve issue #6899 for the incorrect syntax highlighting of escape character 

### DIFF
--- a/Syntaxes/Chapel.tmLanguage
+++ b/Syntaxes/Chapel.tmLanguage
@@ -80,6 +80,17 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.double.chapel</string>
+			<key>patterns</key>
+					<array>
+							<dict>
+								<key>include</key>
+								<string>#string_escaped_char</string>
+							</dict>
+							<dict>
+								<key>include</key>
+								<string>#string_placeholder</string>
+							</dict>
+				 </array>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -258,9 +269,9 @@
 		<dict>
 			<key>match</key>
 			<string>(?x)\b(
-              	abs | max | min | sqrt | write | writeln | read | readln | open | close | 
+              	abs | max | min | sqrt | write | writeln | read | readln | open | close |
 				exit
-			
+
 			)\b</string>
 			<key>name</key>
 			<string>support.function.builtin.chapel</string>
@@ -371,6 +382,44 @@
 			<string>\b(align|as|atomic|begin|break|by|catch|class|cobegin|coforall|continue|delete|dmapped|do|else|enum|except|export|extern|for|forall|if|index|inline|in|iter|label|lambda|let|local|module|new|noinit|on|only|otherwise|pragma|private|proc|public|record|reduce|require|return|scan|select|serial|then|throw|throws|try|union|use|var|when|where|while|with|yield|zip)\b</string>
 			<key>name</key>
 			<string>invalid.illegal.name.chapel</string>
+		</dict>
+		<key>string_escaped_char</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
+					<key>name</key>
+					<string>constant.character.escape.c</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\.</string>
+					<key>name</key>
+					<string>invalid.illegal.unknown-escape.c</string>
+				</dict>
+			</array>
+		</dict>
+		<key>string_placeholder</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>(?x)%
+    						(\d+\$)?                             # field (argument #)
+    						[#0\- +']*                           # flags
+    						[,;:_]?                              # separator character (AltiVec)
+    						((-?\d+)|\*(-?\d+\$)?)?              # minimum field width
+    						(\.((-?\d+)|\*(-?\d+\$)?)?)?         # precision
+    						(hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier
+    						[diouxXDOUeEfFgGaACcSspn%]           # conversion type
+    					</string>
+					<key>name</key>
+					<string>constant.other.placeholder.c</string>
+				</dict>
+			</array>
 		</dict>
 	</dict>
 	<key>scopeName</key>

--- a/Syntaxes/Chapel.tmLanguage
+++ b/Syntaxes/Chapel.tmLanguage
@@ -81,16 +81,16 @@
 			<key>name</key>
 			<string>string.quoted.double.chapel</string>
 			<key>patterns</key>
-					<array>
-							<dict>
-								<key>include</key>
-								<string>#string_escaped_char</string>
-							</dict>
-							<dict>
-								<key>include</key>
-								<string>#string_placeholder</string>
-							</dict>
-				 </array>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#string_escaped_char</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#string_placeholder</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -269,9 +269,9 @@
 		<dict>
 			<key>match</key>
 			<string>(?x)\b(
-              	abs | max | min | sqrt | write | writeln | read | readln | open | close |
+              	abs | max | min | sqrt | write | writeln | read | readln | open | close | 
 				exit
-
+			
 			)\b</string>
 			<key>name</key>
 			<string>support.function.builtin.chapel</string>

--- a/Syntaxes/Chapel.tmLanguage
+++ b/Syntaxes/Chapel.tmLanguage
@@ -80,17 +80,6 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.double.chapel</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#string_escaped_char</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#string_placeholder</string>
-				</dict>
-			</array>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
@lydia-duncan  In the previous PR #8 I have added **#string_escaped_char and #string_placeholder**  in the chapel tmbundle to resolve the issue **Incorrect Syntax Highlighting For Escaped Character '\"' **#6899**** . Here comes their description .
**_Description of changes_** :  The changes here done to correct the syntax highlighting in the Chapel syntax highlighter for escape characters . It lead to correct syntax highlighting for **" \' ", " \ " ", , " \ a ", " \ b ",  " \ f " , " \ e " , " \ n " , " \ r ", " \ t " , " \ v "** and **IPv6 addresses** representation . Also previously in chapel tmbundle code at line 108 
` ` `

			<array>
				<dict>
					<key>include</key>
					<string>#string_escaped_char</string>
				</dict>
			</array>

` ` `
 but there is no description about **#string_escaped_char** in the code . The description of **#string_escaped_char** is also mentioned in this pull request to have correct syntax highlighting . 

Kindly review the changes done 