### PR TITLE
Adding check for escape character to resolve issue #6899

### DIFF
--- a/Syntaxes/Chapel.tmLanguage
+++ b/Syntaxes/Chapel.tmLanguage
@@ -80,6 +80,13 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.double.chapel</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#string_escaped_char</string>
+				</dict>
+			</array>			
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -372,6 +379,24 @@
 			<key>name</key>
 			<string>invalid.illegal.name.chapel</string>
 		</dict>
+		<key>string_escaped_char</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
+					<key>name</key>
+					<string>constant.character.escape.c</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\.</string>
+					<key>name</key>
+					<string>invalid.illegal.unknown-escape.c</string>
+				</dict>
+			</array>
+		</dict>		
 	</dict>
 	<key>scopeName</key>
 	<string>source.chapel</string>


### PR DESCRIPTION
@lydia-duncan I have added check to resolve the issue **Incorrect Syntax Highlighting For Escaped Character '"' #6899** by adding **#string_escaped_char.** As there is no check for the escape character provided in the chapel tmbundle .
**_Description of changes_** :  The changes here done to correct the syntax highlighting in the Chapel syntax highlighter for escape characters . It lead to correct syntax highlighting for **" \' ", " \ " ", , " \ a ", " \ b ",  " \ f " , " \ e " , " \ n " , " \ r ", " \ t " , " \ v "** and **IPv6 addresses** representation . Also previously in chapel tmbundle code at line 108 
` ` `

			<array>
				<dict>
					<key>include</key>
					<string>#string_escaped_char</string>
				</dict>
			</array>

` ` `
 but there is no description about **#string_escaped_char** in the code . The description of **#string_escaped_char** is also mentioned in this pull request to have correct syntax highlighting . 

Kindly review the changes done .