### PR TITLE
Addition of #string_placeholder in Chapel tmbundle to resolve issue #6899 for the incorrect syntax highlighting of escape character

### DIFF
--- a/Syntaxes/Chapel.tmLanguage
+++ b/Syntaxes/Chapel.tmLanguage
@@ -86,6 +86,10 @@
 					<key>include</key>
 					<string>#string_escaped_char</string>
 				</dict>
+				<dict>
+                                        <key>include</key>
+                                        <string>#string_placeholder</string>
+                                </dict>
 			</array>			
 		</dict>
 		<dict>
@@ -394,6 +398,26 @@
 					<string>\\.</string>
 					<key>name</key>
 					<string>invalid.illegal.unknown-escape.c</string>
+				</dict>
+			</array>
+		</dict>
+		<key>string_placeholder</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>(?x)%
+    						(\d+\$)?                             # field (argument #)
+    						[#0\- +']*                           # flags
+    						[,;:_]?                              # separator character (AltiVec)
+    						((-?\d+)|\*(-?\d+\$)?)?              # minimum field width
+    						(\.((-?\d+)|\*(-?\d+\$)?)?)?         # precision
+    						(hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier
+    						[diouxXDOUeEfFgGaACcSspn%]           # conversion type
+    					</string>
+					<key>name</key>
+					<string>constant.other.placeholder.c</string>
 				</dict>
 			</array>
 		</dict>		

--- a/Syntaxes/Chapel.tmLanguage
+++ b/Syntaxes/Chapel.tmLanguage
@@ -80,6 +80,13 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.double.chapel</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#string_escaped_char</string>
+				</dict>
+			</array>			
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -372,6 +379,24 @@
 			<key>name</key>
 			<string>invalid.illegal.name.chapel</string>
 		</dict>
+		<key>string_escaped_char</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
+					<key>name</key>
+					<string>constant.character.escape.c</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\.</string>
+					<key>name</key>
+					<string>invalid.illegal.unknown-escape.c</string>
+				</dict>
+			</array>
+		</dict>		
 	</dict>
 	<key>scopeName</key>
 	<string>source.chapel</string>


### PR DESCRIPTION
@lydia-duncan  In the previous PR #11  I have added **#string_escaped_char**  in the chapel tmbundle to resolve the issue ****Incorrect Syntax Highlighting For Escaped Character** '\"' **#6899** . Here comes the addition of **#string_placeholder** and it's description .
Kindly review the changes done 