### PR TITLE
differentiation in single and double quotes

### DIFF
--- a/Syntaxes/Chapel.tmLanguage
+++ b/Syntaxes/Chapel.tmLanguage
@@ -121,7 +121,11 @@
 					<key>include</key>
 					<string>#string_escaped_char</string>
 				</dict>
-			</array>
+				<dict>
+                                        <key>include</key>
+                                        <string>#string_placeholder</string>
+                                </dict>
+			</array>			
 		</dict>
 		<dict>
 			<key>match</key>


### PR DESCRIPTION
related to issue #21 ,

I've tried to correct the chapel-tmbundle issue and hope that this will work , but right now I am unable to test the solution , since lightshow doesn't clearly show differences in single and double quotes, rest , this won't break the code I hope , Made a different branch till there's a way to verify the solution(which I feel will work though).