### PR TITLE
Add import to the list of control keywords and illegal names

### DIFF
--- a/Syntaxes/Chapel.tmLanguage
+++ b/Syntaxes/Chapel.tmLanguage
@@ -23,7 +23,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(align|as|atomic|begin|borrowed|break|by|catch|class|cobegin|coforall|continue|delete|dmapped|do|else|enum|except|export|extern|for|forall|if|index|inline|in|inout|iter|label|lambda|let|lifetime|local|module|new|noinit|on|only|otherwise|out|override|owned|pragma|private|proc|prototype|public|record|reduce|require|return|scan|select|serial|shared|sync|then|throw|throws|try|union|unmanaged|use|when|where|while|with|yield|zip)\b</string>
+			<string>\b(align|as|atomic|begin|borrowed|break|by|catch|class|cobegin|coforall|continue|delete|dmapped|do|else|enum|except|export|extern|for|forall|if|import|index|inline|in|inout|iter|label|lambda|let|lifetime|local|module|new|noinit|on|only|otherwise|out|override|owned|pragma|private|proc|prototype|public|record|reduce|require|return|scan|select|serial|shared|sync|then|throw|throws|try|union|unmanaged|use|when|where|while|with|yield|zip)\b</string>
 			<key>name</key>
 			<string>keyword.control.chapel</string>
 		</dict>
@@ -378,7 +378,7 @@
 		<key>illegal_names</key>
 		<dict>
 			<key>match</key>
-			<string>\b(align|as|atomic|begin|borrowed|break|by|bytes|catch|class|cobegin|coforall|continue|delete|dmapped|do|else|enum|except|export|extern|for|forall|if|index|inline|in|inout|iter|label|lambda|let|lifetime|local|module|new|noinit|nothing|on|only|otherwise|out|override|owned|pragma|private|proc|public|record|reduce|ref|require|return|scan|select|serial|shared|single|sync|then|throw|throws|try|union|unmanaged|use|var|void|when|where|while|with|yield|zip)\b</string>
+			<string>\b(align|as|atomic|begin|borrowed|break|by|bytes|catch|class|cobegin|coforall|continue|delete|dmapped|do|else|enum|except|export|extern|for|forall|if|import|index|inline|in|inout|iter|label|lambda|let|lifetime|local|module|new|noinit|nothing|on|only|otherwise|out|override|owned|pragma|private|proc|public|record|reduce|ref|require|return|scan|select|serial|shared|single|sync|then|throw|throws|try|union|unmanaged|use|var|void|when|where|while|with|yield|zip)\b</string>
 			<key>name</key>
 			<string>invalid.illegal.name.chapel</string>
 		</dict>


### PR DESCRIPTION
These are all the places that "use" was present.

Verified the behavior with lightshow - import was not highlighted with
master and is highlighted with this change